### PR TITLE
Add a health check for initial data loading

### DIFF
--- a/lib/check/initial-data.js
+++ b/lib/check/initial-data.js
@@ -1,0 +1,77 @@
+/**
+ * Module to create a health check object that checks for the presence of initial data.
+ */
+'use strict';
+
+const Check = require('@financial-times/health-check').Check;
+const isPlainObject = require('lodash/isPlainObject');
+const PackageData = require('../package-data');
+
+/**
+ * Class representing a single health check that checks initial data.
+ */
+module.exports = class InitialDataCheck extends Check {
+
+	/**
+	 * Create an initial data health check. Accepts the same options as Check, but with a few additions.
+	 * @param {Object} options - The health check options.
+	 * @param {String} options.packageData - The package data instance to use in the check.
+	 * @throws {TypeError} Will throw if any options are invalid.
+	 */
+	constructor(options) {
+		InitialDataCheck.assertOptionValidity(options);
+		super(options);
+	}
+
+	/**
+	 * Actually perform the health check. This updates the relevant properties.
+	 * @returns {Promise} A promise which resolves with undefined.
+	 */
+	run() {
+		return this.options.packageData.promise()
+			.then(() => {
+				this.severity = 1;
+				this.ok = true;
+				this.checkOutput = '';
+				this.lastUpdated = new Date();
+			})
+			.catch(error => {
+				this.ok = false;
+				this.checkOutput = error.message;
+				this.lastUpdated = new Date();
+				this.severity = 3;
+				if (error.code === 'E_PACKAGES_NOT_LOADED') {
+					this.severity = 1;
+				}
+				this.log.error(`Health check "${this.options.name}" failed: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Validate health check options against the standard.
+	 * @param {Object} options - The options to check.
+	 * @returns {(Boolean|TypeError)} Will return `true` if the options are valid, or a descriptive error if not.
+	 */
+	static validateOptions(options) {
+		if (!isPlainObject(options)) {
+			return new TypeError('Options must be an object');
+		}
+		if (!(options.packageData instanceof PackageData)) {
+			return new TypeError('Invalid option: packageData must be an instance of PackageData');
+		}
+		return true;
+	}
+
+	/**
+	 * Assert that health check options are valid.
+	 * @param {Object} options - The options to assert validity of.
+	 * @throws {TypeError} Will throw if the options are invalid.
+	 */
+	static assertOptionValidity(options) {
+		const validationResult = InitialDataCheck.validateOptions(options);
+		if (validationResult instanceof Error) {
+			throw validationResult;
+		}
+	}
+
+};

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -1,16 +1,28 @@
 'use strict';
 
 const HealthCheck = require('@financial-times/health-check');
+const InitialDataCheck = require('./check/initial-data');
 
 module.exports = healthChecks;
 
-function healthChecks(options) {
+function healthChecks(options, packageData) {
 
 	// Create and return the health check
 	return new HealthCheck({
 		checks: [
 
-			// TODO add a health check for if no data can be retrieved
+			// This check ensures that initial package data
+			// has been loaded successfully
+			new InitialDataCheck({
+				packageData,
+				interval: 30000,
+				id: 'initial-data',
+				name: 'Initial data has been loaded from the store or GitHub',
+				severity: 1,
+				businessImpact: 'Users may not be able to list or install packages',
+				technicalSummary: 'Checks that initial package data has loaded successfully',
+				panicGuide: 'Check that at least one of GitHub and the Package Data store are functional'
+			}),
 
 			// This check ensures that the package data
 			// store is available. It will fail on a non-200

--- a/lib/service.js
+++ b/lib/service.js
@@ -9,20 +9,22 @@ module.exports = service;
 
 function service(options) {
 
-	const health = healthChecks(options);
+	const packageData = new PackageData(options);
+	packageData.loadInitialData();
+
+	const health = healthChecks(options, packageData);
 	options.healthCheck = health.checks();
 	options.goodToGoTest = health.gtg();
 	options.about = require('../about.json');
 
 	const app = origamiService(options);
 
+	app.origami.packageData = packageData;
+
 	app.use(origamiService.middleware.getBasePath());
 	mountRoutes(app);
 	app.use(origamiService.middleware.notFound());
 	app.use(origamiService.middleware.errorHandler());
-
-	app.origami.packageData = new PackageData(app.origami.options);
-	app.origami.packageData.loadInitialData();
 
 	return app;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "heroku-node-settings index.js"
   },
   "dependencies": {
-    "@financial-times/health-check": "^1.1.0",
+    "@financial-times/health-check": "^1.2.0",
     "@financial-times/origami-service": "^2.0.0",
     "body-parser": "^1.17.2",
     "dotenv": "^2",

--- a/test/unit/lib/check/initial-data.test.js
+++ b/test/unit/lib/check/initial-data.test.js
@@ -1,0 +1,336 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/check/initial-data', () => {
+	let Check;
+	let log;
+	let PackageData;
+	let InitialDataCheck;
+
+	beforeEach(() => {
+		Check = require('@financial-times/health-check').Check;
+
+		log = require('../../mock/log.mock');
+
+		PackageData = require('../../mock/package-data.mock');
+		PackageData.mockPackageData = sinon.createStubInstance(PackageData);
+		PackageData.mockPackageData.promise = sinon.stub().resolves();
+		mockery.registerMock('../package-data', PackageData);
+
+		InitialDataCheck = require('../../../../lib/check/initial-data');
+	});
+
+	it('exports a class constructor', () => {
+		assert.isFunction(InitialDataCheck);
+		/* eslint-disable new-cap */
+		assert.throws(() => InitialDataCheck(), /class constructor .* without 'new'/i);
+		/* eslint-enable new-cap */
+	});
+
+	describe('new InitialDataCheck(options)', () => {
+		let instance;
+		let options;
+		let startMock;
+
+		beforeEach(() => {
+			options = {
+				businessImpact: 'mock business impact',
+				id: 'mock-id',
+				log: log,
+				method: 'MOCK',
+				name: 'mock name',
+				panicGuide: 'mock panic guide',
+				technicalSummary: 'mock technical summary',
+				packageData: PackageData.mockPackageData
+			};
+			sinon.stub(InitialDataCheck, 'assertOptionValidity');
+			startMock = sinon.stub(InitialDataCheck.prototype, 'start');
+			instance = new InitialDataCheck(options);
+			startMock.restore();
+		});
+
+		it('extends Check', () => {
+			assert.instanceOf(instance, Check);
+		});
+
+		it('asserts that the defaulted options are valid', () => {
+			assert.calledOnce(InitialDataCheck.assertOptionValidity);
+			assert.calledWithExactly(InitialDataCheck.assertOptionValidity, options);
+		});
+
+		describe('.run()', () => {
+			let mockDate;
+			let returnedPromise;
+
+			beforeEach(() => {
+				mockDate = {
+					mock: true
+				};
+				sinon.stub(global, 'Date').returns(mockDate);
+				instance.severity = null;
+				instance.ok = false;
+				instance.checkOutput = 'mock output';
+				returnedPromise = instance.run();
+			});
+
+			afterEach(() => {
+				Date.restore();
+			});
+
+			it('calls `packageData.promise` with the expected options', () => {
+				assert.calledOnce(PackageData.mockPackageData.promise);
+				assert.calledWithExactly(PackageData.mockPackageData.promise);
+			});
+
+			it('returns a promise', () => {
+				assert.instanceOf(returnedPromise, Promise);
+			});
+
+			describe('.then()', () => {
+				let resolvedValue;
+
+				beforeEach(() => {
+					return returnedPromise.then(value => {
+						resolvedValue = value;
+					});
+				});
+
+				it('resolves with nothing', () => {
+					assert.isUndefined(resolvedValue);
+				});
+
+				it('sets the `severity` property to 1', () => {
+					assert.strictEqual(instance.severity, 1);
+				});
+
+				it('sets the `ok` property to `true`', () => {
+					assert.isTrue(instance.ok);
+				});
+
+				it('sets the `checkOutput` property to an empty string', () => {
+					assert.strictEqual(instance.checkOutput, '');
+				});
+
+				it('updates the `lastUpdated` property', () => {
+					assert.strictEqual(instance.lastUpdated, mockDate);
+				});
+
+			});
+
+			describe('when the promise rejects', () => {
+				let dataError;
+
+				beforeEach(() => {
+					instance.ok = true;
+					instance.checkOutput = '';
+					instance.severity = null;
+					dataError = new Error('data error');
+					PackageData.mockPackageData.promise.reset();
+					PackageData.mockPackageData.promise.rejects(dataError);
+					returnedPromise = instance.run();
+				});
+
+				describe('.then()', () => {
+					let resolvedValue;
+
+					beforeEach(() => {
+						return returnedPromise.then(value => {
+							resolvedValue = value;
+						});
+					});
+
+					it('resolves with nothing', () => {
+						assert.isUndefined(resolvedValue);
+					});
+
+					it('sets the `severity` property to 3', () => {
+						assert.strictEqual(instance.severity, 3);
+					});
+
+					it('sets the `ok` property to `false`', () => {
+						assert.isFalse(instance.ok);
+					});
+
+					it('sets the `checkOutput` property to the error message', () => {
+						assert.strictEqual(instance.checkOutput, 'data error');
+					});
+
+					it('updates the `lastUpdated` property', () => {
+						assert.strictEqual(instance.lastUpdated, mockDate);
+					});
+
+					it('logs that the request failed', () => {
+						assert.calledWithExactly(log.error, 'Health check "mock name" failed: data error');
+					});
+
+				});
+
+			});
+
+			describe('when the promise rejects with an error code of "E_PACKAGES_NOT_LOADED"', () => {
+				let dataError;
+
+				beforeEach(() => {
+					instance.ok = true;
+					instance.checkOutput = '';
+					instance.severity = null;
+					dataError = new Error('data error');
+					dataError.code = 'E_PACKAGES_NOT_LOADED';
+					PackageData.mockPackageData.promise.reset();
+					PackageData.mockPackageData.promise.rejects(dataError);
+					returnedPromise = instance.run();
+				});
+
+				describe('.then()', () => {
+					let resolvedValue;
+
+					beforeEach(() => {
+						return returnedPromise.then(value => {
+							resolvedValue = value;
+						});
+					});
+
+					it('resolves with nothing', () => {
+						assert.isUndefined(resolvedValue);
+					});
+
+					it('sets the `severity` property to 1', () => {
+						assert.strictEqual(instance.severity, 1);
+					});
+
+					it('sets the `ok` property to `false`', () => {
+						assert.isFalse(instance.ok);
+					});
+
+					it('sets the `checkOutput` property to the error message', () => {
+						assert.strictEqual(instance.checkOutput, 'data error');
+					});
+
+					it('updates the `lastUpdated` property', () => {
+						assert.strictEqual(instance.lastUpdated, mockDate);
+					});
+
+					it('logs that the request failed', () => {
+						assert.calledWithExactly(log.error, 'Health check "mock name" failed: data error');
+					});
+
+				});
+
+			});
+
+		});
+
+		describe('.inspect()', () => {
+
+			it('returns a string with the check name and status', () => {
+				assert.match(instance.inspect(), /^InitialDataCheck /);
+			});
+
+		});
+
+	});
+
+	it('has a `validateOptions` static method', () => {
+		assert.isFunction(InitialDataCheck.validateOptions);
+	});
+
+	describe('.validateOptions(options)', () => {
+		let options;
+		let returnValue;
+
+		beforeEach(() => {
+			options = {
+				packageData: PackageData.mockPackageData
+			};
+			returnValue = InitialDataCheck.validateOptions(options);
+		});
+
+		it('returns `true`', () => {
+			assert.isTrue(returnValue);
+		});
+
+		describe('when `options` is not an object', () => {
+
+			it('returns a descriptive error', () => {
+				const expectedErrorMessage = 'Options must be an object';
+				returnValue = InitialDataCheck.validateOptions('');
+				assert.instanceOf(returnValue, TypeError);
+				assert.strictEqual(returnValue.message, expectedErrorMessage);
+				returnValue = InitialDataCheck.validateOptions([]);
+				assert.instanceOf(returnValue, TypeError);
+				assert.strictEqual(returnValue.message, expectedErrorMessage);
+				returnValue = InitialDataCheck.validateOptions(null);
+				assert.instanceOf(returnValue, TypeError);
+				assert.strictEqual(returnValue.message, expectedErrorMessage);
+			});
+
+		});
+
+		describe('when `options` has an invalid `packageData` property', () => {
+
+			it('returns a descriptive error', () => {
+				const expectedErrorMessage = 'Invalid option: packageData must be an instance of PackageData';
+				options.packageData = '';
+				returnValue = InitialDataCheck.validateOptions(options);
+				assert.instanceOf(returnValue, TypeError);
+				assert.strictEqual(returnValue.message, expectedErrorMessage, 'empty string');
+				options.packageData = 123;
+				returnValue = InitialDataCheck.validateOptions(options);
+				assert.instanceOf(returnValue, TypeError);
+				assert.strictEqual(returnValue.message, expectedErrorMessage, 'non-string');
+			});
+
+		});
+
+	});
+
+	it('has an `assertOptionValidity` static method', () => {
+		assert.isFunction(InitialDataCheck.assertOptionValidity);
+	});
+
+	describe('.assertOptionValidity(options)', () => {
+		let options;
+
+		beforeEach(() => {
+			options = {
+				mock: true
+			};
+			sinon.stub(InitialDataCheck, 'validateOptions').returns(true);
+		});
+
+		it('validates the options', () => {
+			InitialDataCheck.assertOptionValidity(options);
+			assert.calledOnce(InitialDataCheck.validateOptions);
+			assert.calledWithExactly(InitialDataCheck.validateOptions, options);
+		});
+
+		it('does not throw', () => {
+			assert.doesNotThrow(() => InitialDataCheck.assertOptionValidity(options));
+		});
+
+		describe('when the options are invalid', () => {
+			let mockError;
+
+			beforeEach(() => {
+				mockError = new Error('mock error');
+				InitialDataCheck.validateOptions.returns(mockError);
+			});
+
+			it('throws a validation error', () => {
+				let caughtError;
+				try {
+					InitialDataCheck.assertOptionValidity(options);
+				} catch (error) {
+					caughtError = error;
+				}
+				assert.strictEqual(caughtError, mockError);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/health-checks.js
+++ b/test/unit/lib/health-checks.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 describe('lib/health-checks', () => {
 	let healthChecks;
 	let HealthCheck;
+	let InitialDataCheck;
 	let log;
 	let mockHealthCheck;
 
@@ -16,6 +17,9 @@ describe('lib/health-checks', () => {
 		};
 		HealthCheck = sinon.stub().returns(mockHealthCheck);
 		mockery.registerMock('@financial-times/health-check', HealthCheck);
+
+		InitialDataCheck = sinon.stub();
+		mockery.registerMock('./check/initial-data', InitialDataCheck);
 
 		log = require('../mock/log.mock');
 

--- a/test/unit/lib/service.js
+++ b/test/unit/lib/service.js
@@ -64,7 +64,7 @@ describe('lib/service', () => {
 
 		it('creates a healthChecks object', () => {
 			assert.calledOnce(healthChecks);
-			assert.calledWithExactly(healthChecks, options);
+			assert.calledWithExactly(healthChecks, options, PackageData.mockPackageData);
 		});
 
 		it('sets `options.healthCheck` to the created health check function', () => {
@@ -116,7 +116,7 @@ describe('lib/service', () => {
 		it('creates a package data instance', () => {
 			assert.calledOnce(PackageData);
 			assert.calledWithNew(PackageData);
-			assert.calledWith(PackageData, origamiService.mockApp.origami.options);
+			assert.calledWith(PackageData, options);
 		});
 
 		it('sets the application `origami.packageData` property to the package data instance', () => {

--- a/test/unit/mock/package-data.mock.js
+++ b/test/unit/mock/package-data.mock.js
@@ -5,7 +5,8 @@ const sinon = require('sinon');
 const PackageData = module.exports = sinon.stub();
 
 const mockPackageData = module.exports.mockPackageData = {
-	loadInitialData: sinon.stub()
+	loadInitialData: sinon.stub(),
+	promise: sinon.stub()
 };
 
 PackageData.returns(mockPackageData);


### PR DESCRIPTION
The check will be severity 3 while we're waiting for data to load, then
will increase to severity 1 if both GitHub and the S3 bucket are
failing. This means we won't be spammed by alerts in startup.