### PR TITLE
Publish new repositories to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ We configure Origami Bower Registry using environment variables. In development,
 
 ### Required everywhere
 
+  * `AWS_ACCESS_KEY`: The API key used to publish packages to S3.
+  * `AWS_SECRET_KEY`: The secret key used to publish packages to S3.
   * `GITHUB_SECRET`: The secret used when communicating with the Github Webhooks.
   * `GITHUB_TOKEN`: The oauth token to use when communicating with the Github API.
   * `NODE_ENV`: The environment to run the application in. One of `production`, `development` (default), or `test` (for use in automated tests).
   * `PACKAGE_DATA_STORE`: The location of the JSON packages data that powers the service. This should be a URL.
   * `PORT`: The port to run the application on.
+  * `S3_BUCKETS`: Comma-separated S3 bucket names to publish packages to.
 
 ### Required in Heroku
 

--- a/index.js
+++ b/index.js
@@ -8,12 +8,15 @@ dotenv.load({
 	silent: true
 });
 const options = {
+	awsAccessKey: process.env.AWS_ACCESS_KEY,
+	awsSecretKey: process.env.AWS_SECRET_KEY,
 	defaultLayout: 'main',
 	githubSecret: process.env.GITHUB_SECRET,
 	githubToken: process.env.GITHUB_TOKEN,
 	log: console,
 	name: 'Origami Bower Registry',
 	packageDataStore: process.env.PACKAGE_DATA_STORE || 'https://www.ft.com/__origami/service/bower-registry-data',
+	s3Buckets: (process.env.S3_BUCKETS ? process.env.S3_BUCKETS.split(',') : []),
 	workers: process.env.WEB_CONCURRENCY || 1
 };
 

--- a/lib/package-data.js
+++ b/lib/package-data.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const AWS = require('aws-sdk');
 const request = require('request-promise-native');
 const githubPublicOrganisationRepositories = require('github-public-organisation-repositories');
+
 /**
  * Class representing Bower package data.
  */
@@ -12,6 +14,9 @@ module.exports = class PackageData {
 	 * @param {Object} options - The package data options.
 	 * @param {String} options.packageDataStore - The base URL of the service where initial package data will be loaded from.
 	 * @param {String} options.githubToken - The oauth token to use when communicating with the Github API.
+	 * @param {String} options.awsAccessKey - The access key to use when communicating with S3.
+	 * @param {String} options.awsSecretKey - The secret key to use when communicating with S3.
+	 * @param {String[]} options.s3Buckets - An array of S3 bucket names to upload packages data to.
 	 * @throws {TypeError} Will throw if any options are invalid.
 	 */
 	constructor(options = {}) {
@@ -24,6 +29,18 @@ module.exports = class PackageData {
 
 		if (typeof options.githubToken !== 'string') {
 			throw new TypeError('The githubToken option must be a string');
+		}
+
+		if (typeof options.awsAccessKey !== 'string') {
+			throw new TypeError('The awsAccessKey option must be a string');
+		}
+
+		if (typeof options.awsSecretKey !== 'string') {
+			throw new TypeError('The awsSecretKey option must be a string');
+		}
+
+		if (!Array.isArray(options.s3Buckets)) {
+			throw new TypeError('The s3Buckets option must be an array');
 		}
 
 		options.packageDataStore = options.packageDataStore.replace(/\/$/, '');
@@ -82,13 +99,49 @@ module.exports = class PackageData {
 			})
 			.then(packages => {
 				this.data = packages;
-				return packages;
+				return this.publishToS3();
+			})
+			.then(() => {
+				return this.data;
 			})
 			.catch(error => {
 				if (this.log && this.log.error) {
 					this.log.error(`Packages could not be loaded from Github: ${error.message}`);
 				}
 			});
+	}
+
+	/**
+	 * Save the local cache of package data to S3.
+	 * @returns {Promise} Will always return a promise which resolves with `undefined`.
+	 */
+	publishToS3() {
+		const s3 = new AWS.S3({
+			accessKeyId: this.options.awsAccessKey,
+			secretAccessKey: this.options.awsSecretKey
+		});
+		const uploadConfig = {
+			ACL: 'public-read',
+			Body: JSON.stringify(this.data),
+			ContentType: 'application/json',
+			Key: 'packages.json'
+		};
+		return Promise.all(this.options.s3Buckets.map(bucket => {
+			if (this.log && this.log.info) {
+				this.log.info(`Publishing package data to S3 bucket: ${bucket}…`);
+			}
+			return s3.upload(Object.assign({
+				Bucket: bucket
+			}, uploadConfig)).promise();
+		}))
+		.then(() => {
+			this.log.info(`Package data published to S3`);
+		})
+		.catch(error => {
+			if (this.log && this.log.error) {
+				this.log.error(`Packages could not be published to S3: ${error.message}`);
+			}
+		});
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@financial-times/health-check": "^1.2.0",
     "@financial-times/origami-service": "^2.1.2",
     "@financial-times/origami-service-makefile": "^2.0.0",
+    "aws-sdk": "^2.102.0",
     "body-parser": "^1.17.2",
     "dotenv": "^2",
     "github-public-organisation-repositories": "^1.0.2",

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -21,13 +21,16 @@ before(function() {
 		})
 		.then(() => {
 			return service({
+				awsAccessKey: 'aws-access',
+				awsSecretKey: 'aws-secret',
 				environment: 'test',
 				log: mockLog,
 				githubToken: '',
 				githubSecret: 'secret',
 				port: null,
 				packageDataStore: this.mockPackageStore.address,
-				requestLogFormat: null
+				requestLogFormat: null,
+				s3Buckets: []
 			}).listen();
 		})
 		.then(app => {

--- a/test/unit/lib/package-data.js
+++ b/test/unit/lib/package-data.js
@@ -5,6 +5,7 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 
 describe('lib/package-data', () => {
+	let AWS;
 	let githubPublicOrganisationRepositories;
 	let log;
 	let PackageData;
@@ -12,6 +13,9 @@ describe('lib/package-data', () => {
 
 	beforeEach(() => {
 		log = require('../mock/log.mock');
+
+		AWS = require('../mock/aws-sdk.mock');
+		mockery.registerMock('aws-sdk', AWS);
 
 		githubPublicOrganisationRepositories = require('../mock/github-public-organisation-repositories.mock');
 		mockery.registerMock('github-public-organisation-repositories', githubPublicOrganisationRepositories);
@@ -32,9 +36,15 @@ describe('lib/package-data', () => {
 
 		beforeEach(() => {
 			options = {
+				awsAccessKey: 'mock-aws-access-key',
+				awsSecretKey: 'mock-aws-secret-key',
 				githubToken: 'abcdef',
 				log: log,
-				packageDataStore: 'mock-package-store'
+				packageDataStore: 'mock-package-store',
+				s3Buckets: [
+					'mock-bucket-1',
+					'mock-bucket-2'
+				]
 			};
 			instance = new PackageData(options);
 		});
@@ -247,6 +257,7 @@ describe('lib/package-data', () => {
 					}
 				];
 				githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories.resolves(mockPackages);
+				sinon.stub(instance, 'publishToS3');
 				returnedPromise = instance.loadFromGitHub();
 				return returnedPromise.then(value => {
 					resolvedValue = value;
@@ -273,6 +284,11 @@ describe('lib/package-data', () => {
 
 			it('sets the `data` property to the resolved packages', () => {
 				assert.strictEqual(instance.data, mockPackages);
+			});
+
+			it('publishes the loaded packages to S3', () => {
+				assert.calledOnce(instance.publishToS3);
+				assert.calledWithExactly(instance.publishToS3);
 			});
 
 			describe('when the Github request errors', () => {
@@ -329,6 +345,94 @@ describe('lib/package-data', () => {
 						assert.neverCalledWith(log.error, 'Packages could not be loaded from Github: mock Github error');
 					});
 
+				});
+
+			});
+
+		});
+
+		it('has a `publishToS3` method', () => {
+			assert.isFunction(instance.publishToS3);
+		});
+
+		describe('.publishToS3()', () => {
+			let returnedPromise;
+			let resolvedValue;
+
+			beforeEach(() => {
+				instance.data = [
+					{
+						name: 'mock-package'
+					}
+				];
+				returnedPromise = instance.publishToS3();
+				return returnedPromise.then(value => {
+					resolvedValue = value;
+				});
+			});
+
+			it('returns a promise', () => {
+				assert.instanceOf(returnedPromise, Promise);
+			});
+
+			it('creates an S3 instance', () => {
+				assert.calledOnce(AWS.S3);
+				assert.calledWithNew(AWS.S3);
+				assert.calledWith(AWS.S3, {
+					accessKeyId: options.awsAccessKey,
+					secretAccessKey: options.awsSecretKey
+				});
+			});
+
+			it('uploads the packages data to each bucket', () => {
+				assert.calledTwice(AWS.S3.mockInstance.upload);
+				assert.calledTwice(AWS.S3.mockUpload.promise);
+				assert.calledWith(AWS.S3.mockInstance.upload.firstCall, {
+					ACL: 'public-read',
+					Body: '[{"name":"mock-package"}]',
+					Bucket: 'mock-bucket-1',
+					ContentType: 'application/json',
+					Key: 'packages.json'
+				});
+				assert.calledWith(AWS.S3.mockInstance.upload.secondCall, {
+					ACL: 'public-read',
+					Body: '[{"name":"mock-package"}]',
+					Bucket: 'mock-bucket-2',
+					ContentType: 'application/json',
+					Key: 'packages.json'
+				});
+			});
+
+			it('resolves with nothing', () => {
+				assert.isUndefined(resolvedValue);
+			});
+
+			describe('when the S3 upload errors', () => {
+
+				beforeEach(() => {
+					AWS.S3.mockUpload.promise.reset();
+					AWS.S3.mockUpload.promise.rejects(new Error('mock S3 error'));
+					return instance.publishToS3();
+				});
+
+				it('logs the error', () => {
+					assert.called(log.error);
+					assert.calledWith(log.error, 'Packages could not be published to S3: mock S3 error');
+				});
+
+			});
+
+			describe('when the S3 upload errors and no logger is specified', () => {
+
+				beforeEach(() => {
+					delete instance.log;
+					AWS.S3.mockUpload.promise.reset();
+					AWS.S3.mockUpload.promise.rejects(new Error('mock S3 error'));
+					return instance.publishToS3();
+				});
+
+				it('does not log the error', () => {
+					assert.neverCalledWith(log.error, 'Packages could not be published to S3: mock S3 error');
 				});
 
 			});
@@ -438,6 +542,43 @@ describe('lib/package-data', () => {
 				assert.throws(() => new PackageData({
 					packageDataStore: ''
 				}), 'The githubToken option must be a string');
+			});
+
+		});
+
+		describe('when `options.awsAccessKey` is not a string', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => new PackageData({
+					packageDataStore: '',
+					githubToken: ''
+				}), 'The awsAccessKey option must be a string');
+			});
+
+		});
+
+		describe('when `options.awsSecretKey` is not a string', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => new PackageData({
+					packageDataStore: '',
+					githubToken: '',
+					awsAccessKey: ''
+				}), 'The awsSecretKey option must be a string');
+			});
+
+		});
+
+		describe('when `options.s3Buckets` is not a string', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => new PackageData({
+					packageDataStore: '',
+					githubToken: '',
+					awsAccessKey: '',
+					awsSecretKey: '',
+					s3Buckets: null
+				}), 'The s3Buckets option must be an array');
 			});
 
 		});

--- a/test/unit/mock/aws-sdk.mock.js
+++ b/test/unit/mock/aws-sdk.mock.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const AWS = module.exports = {};
+
+AWS.S3 = sinon.stub();
+AWS.S3.mockInstance = {
+	upload: sinon.stub()
+};
+AWS.S3.mockUpload = {
+	promise: sinon.stub().resolves()
+};
+
+AWS.S3.returns(AWS.S3.mockInstance);
+AWS.S3.mockInstance.upload.returns(AWS.S3.mockUpload);


### PR DESCRIPTION
Every time repositories are loaded from GitHub, they are now published
to S3. This speeds up boot time and reduces our reliance on GitHub being
available.

This resolves #33