### PR TITLE
Allow crawling of multiple GitHub organisations

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ const options = {
 	defaultLayout: 'main',
 	githubSecret: process.env.GITHUB_SECRET,
 	githubToken: process.env.GITHUB_TOKEN,
+	githubOrganisations: [
+		'financial-times',
+		'ftlabs'
+	],
 	log: console,
 	name: 'Origami Bower Registry',
 	packageDataStore: process.env.PACKAGE_DATA_STORE || 'https://origami-bower-registry-data.ft.com/',

--- a/lib/package-data.js
+++ b/lib/package-data.js
@@ -43,6 +43,10 @@ module.exports = class PackageData {
 			throw new TypeError('The s3Buckets option must be an array');
 		}
 
+		if (!Array.isArray(options.githubOrganisations)) {
+			throw new TypeError('The githubOrganisations option must be an array');
+		}
+
 		options.packageDataStore = options.packageDataStore.replace(/\/$/, '');
 		this.packageDataStorePath = `${this.options.packageDataStore}/packages.json`;
 
@@ -95,10 +99,12 @@ module.exports = class PackageData {
 		return Promise.resolve()
 			.then(() => {
 				const getPublicOrganisationRepositories = githubPublicOrganisationRepositories(this.options.githubToken);
-				return getPublicOrganisationRepositories('financial-times');
+				return Promise.all(this.options.githubOrganisations.map(githubOrganisation => {
+					return getPublicOrganisationRepositories(githubOrganisation);
+				}));
 			})
 			.then(packages => {
-				this.data = packages;
+				this.data = [].concat(...packages).sort(sortAlphabeticallyByProperty('name'));
 				return this.publishToS3();
 			})
 			.then(() => {
@@ -173,3 +179,18 @@ module.exports = class PackageData {
 	}
 
 };
+
+// Create a function that sorts an array alphabetically by object properties
+function sortAlphabeticallyByProperty(property) {
+	return (a, b) => {
+		a = a[property].toLowerCase();
+		b = b[property].toLowerCase();
+		if (a < b) {
+			return -1;
+		}
+		if (a > b) {
+			return 1;
+		}
+		return 0;
+	};
+}

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -27,6 +27,9 @@ before(function() {
 				log: mockLog,
 				githubToken: '',
 				githubSecret: 'secret',
+				githubOrganisations: [
+					'financial-times'
+				],
 				port: null,
 				packageDataStore: this.mockPackageStore.address,
 				requestLogFormat: null,

--- a/test/unit/lib/package-data.js
+++ b/test/unit/lib/package-data.js
@@ -39,6 +39,10 @@ describe('lib/package-data', () => {
 				awsAccessKey: 'mock-aws-access-key',
 				awsSecretKey: 'mock-aws-secret-key',
 				githubToken: 'abcdef',
+				githubOrganisations: [
+					'mock-org-1',
+					'mock-org-2'
+				],
 				log: log,
 				packageDataStore: 'mock-package-store',
 				s3Buckets: [
@@ -246,17 +250,27 @@ describe('lib/package-data', () => {
 		});
 
 		describe('.loadFromGitHub()', () => {
-			let mockPackages;
+			let mockPackages1;
+			let mockPackages2;
 			let returnedPromise;
 			let resolvedValue;
 
 			beforeEach(() => {
-				mockPackages = [
+				mockPackages1 = [
 					{
 						name: 'mock-package'
 					}
 				];
-				githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories.resolves(mockPackages);
+				mockPackages2 = [
+					{
+						name: 'aaa-mock-package'
+					},
+					{
+						name: '000-mock-package'
+					}
+				];
+				githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories.withArgs('mock-org-1').resolves(mockPackages1);
+				githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories.withArgs('mock-org-2').resolves(mockPackages2);
 				sinon.stub(instance, 'publishToS3');
 				returnedPromise = instance.loadFromGitHub();
 				return returnedPromise.then(value => {
@@ -273,17 +287,38 @@ describe('lib/package-data', () => {
 				assert.calledWith(githubPublicOrganisationRepositories, options.githubToken);
 			});
 
-			it('makes a request for all public repos in financial-times', () => {
-				assert.calledOnce(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories);
-				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'financial-times');
+			it('makes a request for all public repos in each of the configured organisations', () => {
+				assert.calledTwice(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories);
+				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-1');
+				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-2');
 			});
 
-			it('resolves with the packages', () => {
-				assert.strictEqual(resolvedValue, mockPackages);
+			it('resolves with the packages concatenated together and sorted', () => {
+				assert.deepEqual(resolvedValue, [
+					{
+						name: '000-mock-package'
+					},
+					{
+						name: 'aaa-mock-package'
+					},
+					{
+						name: 'mock-package'
+					}
+				]);
 			});
 
 			it('sets the `data` property to the resolved packages', () => {
-				assert.strictEqual(instance.data, mockPackages);
+				assert.deepEqual(instance.data, [
+					{
+						name: '000-mock-package'
+					},
+					{
+						name: 'aaa-mock-package'
+					},
+					{
+						name: 'mock-package'
+					}
+				]);
 			});
 
 			it('publishes the loaded packages to S3', () => {
@@ -569,7 +604,7 @@ describe('lib/package-data', () => {
 
 		});
 
-		describe('when `options.s3Buckets` is not a string', () => {
+		describe('when `options.s3Buckets` is not an array', () => {
 
 			it('throws an error', () => {
 				assert.throws(() => new PackageData({
@@ -579,6 +614,21 @@ describe('lib/package-data', () => {
 					awsSecretKey: '',
 					s3Buckets: null
 				}), 'The s3Buckets option must be an array');
+			});
+
+		});
+
+		describe('when `options.githubOrganisations` is not an array', () => {
+
+			it('throws an error', () => {
+				assert.throws(() => new PackageData({
+					packageDataStore: '',
+					githubToken: '',
+					awsAccessKey: '',
+					awsSecretKey: '',
+					s3Buckets: [],
+					githubOrganisations: null
+				}), 'The githubOrganisations option must be an array');
 			});
 
 		});


### PR DESCRIPTION
This is part of the work required for #39, and we currently crawl both
ftlabs and financial-times. The last things we need to do are:

  1. Update the list of organisations to include all of the ones we
     need. E.g. do we want to include interactive graphics etc

  2. Add organisation-wide GitHub hooks to each of these organisations
     and ensure that the `/packages/refresh` endpoint can verify them
     all - we may need to support multiple gitHub webhook secrets