### PR TITLE
Add a private repo whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ const options = {
 		'financial-times',
 		'ftlabs'
 	],
+	privateRepoWhitelist: [
+		'o-fonts-assets'
+	],
 	log: console,
 	name: 'Origami Bower Registry',
 	packageDataStore: process.env.PACKAGE_DATA_STORE || 'https://origami-bower-registry-data.ft.com/',

--- a/lib/package-data.js
+++ b/lib/package-data.js
@@ -14,6 +14,8 @@ module.exports = class PackageData {
 	 * @param {Object} options - The package data options.
 	 * @param {String} options.packageDataStore - The base URL of the service where initial package data will be loaded from.
 	 * @param {String} options.githubToken - The oauth token to use when communicating with the Github API.
+	 * @param {Array} options.githubOrganisations - An array of GitHub organisations to get packages for.
+	 * @param {Array} options.privateRepoWhitelist - An array of private repo names which should be injested.
 	 * @param {String} options.awsAccessKey - The access key to use when communicating with S3.
 	 * @param {String} options.awsSecretKey - The secret key to use when communicating with S3.
 	 * @param {String[]} options.s3Buckets - An array of S3 bucket names to upload packages data to.
@@ -100,7 +102,7 @@ module.exports = class PackageData {
 			.then(() => {
 				const getPublicOrganisationRepositories = githubPublicOrganisationRepositories(this.options.githubToken);
 				return Promise.all(this.options.githubOrganisations.map(githubOrganisation => {
-					return getPublicOrganisationRepositories(githubOrganisation);
+					return getPublicOrganisationRepositories(githubOrganisation, this.options.privateRepoWhitelist);
 				}));
 			})
 			.then(packages => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "aws-sdk": "^2.102.0",
     "body-parser": "^1.17.2",
     "dotenv": "^2",
-    "github-public-organisation-repositories": "^1.0.2",
+    "github-public-organisation-repositories": "^1.1.0",
     "heroku-node-settings": "^1.0.2",
     "http-errors": "^1",
     "request": "^2.81.0",

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -32,6 +32,7 @@ before(function() {
 				],
 				port: null,
 				packageDataStore: this.mockPackageStore.address,
+				privateRepoWhitelist: [],
 				requestLogFormat: null,
 				s3Buckets: []
 			}).listen();

--- a/test/unit/lib/package-data.js
+++ b/test/unit/lib/package-data.js
@@ -45,6 +45,10 @@ describe('lib/package-data', () => {
 				],
 				log: log,
 				packageDataStore: 'mock-package-store',
+				privateRepoWhitelist: [
+					'mock-whitelist-1',
+					'mock-whitelist-2'
+				],
 				s3Buckets: [
 					'mock-bucket-1',
 					'mock-bucket-2'
@@ -289,8 +293,8 @@ describe('lib/package-data', () => {
 
 			it('makes a request for all public repos in each of the configured organisations', () => {
 				assert.calledTwice(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories);
-				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-1');
-				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-2');
+				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-1', options.privateRepoWhitelist);
+				assert.calledWith(githubPublicOrganisationRepositories.mockGetPublicOrganisationRepositories, 'mock-org-2', options.privateRepoWhitelist);
 			});
 
 			it('resolves with the packages concatenated together and sorted', () => {


### PR DESCRIPTION
We can now allow the publishing of private repositories. Currently this
is static and in the code itself, if we need to move this into config or
a database later then we can do.

I'm going to check the existing database for any private repositories
next, so that we don't miss any.

This resolves #38