### PR TITLE
Fix a bash issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ endif
 
 # Auto-version the source code and create a GitHub release
 version:
-	@if [ "$(REGION)" == "QA" ] || [ -n "$(CI)" ]; then \
-		if [ -z "$(SOURCE_VERSION)" ]; then echo "Error: SOURCE_VERSION is not set" && exit 0; fi; \
+	@if [ "$(REGION)" = "QA" ] || [ -n "$(CI)" ]; then \
+		if [ -z "$(SOURCE_VERSION)" ]; then echo "Error: SOURCE_VERSION is not set" && exit 1; fi; \
 		if [ -z "$(GITHUB_RELEASE_TOKEN)" ]; then echo "Error: GITHUB_RELEASE_TOKEN is not set" && exit 1; fi; \
 		if [ -z "$(GITHUB_RELEASE_USER)" ]; then echo "Error: GITHUB_RELEASE_USER is not set" && exit 1; fi; \
 		if [ -z "$(GITHUB_RELEASE_REPO)" ]; then echo "Error: GITHUB_RELEASE_REPO is not set" && exit 1; fi; \


### PR DESCRIPTION
On Heroku, Make seems to run with `sh` rather than `bash`. `sh` doesn't
like "==" and so this is breaking. I _think_ that's why anyway