### PR TITLE
Update documentation to use latest Origami majors

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -1,0 +1,7 @@
+@charset "UTF-8";
+
+/* Header overrides */
+
+.o-header-services__logo {
+	background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:origami?format=svg&source=origami&width=55);
+}

--- a/views/error.html
+++ b/views/error.html
@@ -1,5 +1,5 @@
-<h1>
-	{{title}}
-</h1>
 
-<p>{{error.message}}</p>
+<div class="o-layout__main o-layout-typography">
+	<h1>{{title}}</h1>
+	<p>{{error.message}}</p>
+</div>

--- a/views/index.html
+++ b/views/index.html
@@ -1,17 +1,22 @@
-<h1>Install Financial Times GitHub repositories as Bower components</h1>
+<div class="o-layout__hero o-layout-typography">
+	<h1>Origami Bower Registry</h1>
+	<p>
+		A <a href="https://bower.io/">Bower</a>-compatible JSON API which lists all public
+		repositories owned by the Financial Times as well as a
+		<a href="#private-repository-listing">white-list of private repositories</a>.
+	</p>
+</div>
 
-<p>
-	The Origami Bower Registry is a Bower-compatible JSON API which lists all public
-	repositories owned by the Financial Times as well as a
-	<a href="#private-repository-listing">white-list of private repositories</a>.
-</p>
+<div class="o-layout__main o-layout-typography">
 
-<p>
-	To use the Origami Bower registry, update your <code>~/.bowerrc</code> file to
-	the following:
-</p>
-
-<pre><code class="o-syntax-highlight--json">{
+	<div class="o-layout__overview">
+		<div class="o-layout-item">
+			<h2 id="usage">Usage</h2>
+			<p>
+				To use the Origami Bower registry, update your <code>~/.bowerrc</code> file to
+				the following:
+			</p>
+			<pre><code class="o-syntax-highlight--json">{
 	"registry": {
 		"search": [
 			"https://origami-bower-registry.ft.com",
@@ -19,29 +24,32 @@
 		]
 	}
 }</code></pre>
+		</div>
 
-<h2 id="private-repository-listing">Private Repository Listing</h2>
+		<div class="o-layout-item">
+			<h2 id="private-repository-listing">Private Repository Listing</h2>
+			<p>
+				This Bower registry can also list private repositories, but this is decided on a case-by-case
+				basis. If you'd like to add your private repo to the white-list, then you'll need to
+				consider the following first:
+			</p>
+			<ul>
+				<li>
+					Although the repository itself will remain private, the <em>name</em> of it will
+					become publicly viewable through the registry. Depending on the repo name, this
+					may present a privacy concern for you
+				</li>
+				<li>
+					Despite being listed, a Bower user may still not be able to actually install the
+					module – this will depend on their GitHub permissions. This could be confusing
+				</li>
+			</ul>
+			<p>
+				If you're OK with the above then either <a href="mailto:origami.support@ft.com">contact the Origami team</a>
+				asking to add your repository, or <a href="https://github.com/Financial-Times/origami-bower-registry/blob/master/index.js">add it to the <code>privateRepoWhitelist</code> array yourself</a>
+				and open a pull request.
+			</p>
+		</div>
+	</div>
 
-<p>
-	The registry can also list private repositories, but this is decided on a case-by-case
-	basis. If you'd like to add your private repo to the white-list, then you'll need to
-	consider the following first:
-</p>
-
-<ul>
-	<li>
-		Although the repository itself will remain private, the <em>name</em> of it will
-		become publicly viewable through the registry. Depending on the repo name, this
-		may present a privacy concern for you
-	</li>
-	<li>
-		Despite being listed, a Bower user may still not be able to actually install the
-		module – this will depend on their GitHub permissions. This could be confusing
-	</li>
-</ul>
-
-<p>
-	If you're OK with the above then either <a href="mailto:origami.support@ft.com">contact the Origami team</a>
-	asking to add your repository, or <a href="https://github.com/Financial-Times/origami-bower-registry/blob/519900207a480dc4b2957d70fec88dcd1715f18c/index.js#L20-L22">add it to the whitelist yourself</a>
-	and open a pull request.
-</p>
+</div>

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -22,19 +22,10 @@
 			.enhanced .o--if-no-js {
 				display: none !important;
 			}
-			html {
-				font-family: BentonSans, sans-serif;
-				overflow-x: hidden;
-			}
-			body {
-				margin: 0;
-			}
-			.o-layout__header .o-header-services__top .o-header-services__ftlogo {
-				background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:origami?source=origami-build-service");
-			}
 		</style>
 
-		<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^2.0.1,o-fonts@^3.0.4,o-syntax-highlight@^1.5.1" />
+		<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-header-services@^4.0.3,o-footer-services@^3.0.2&brand=internal" />
+		<link rel="stylesheet" href="main.css" />
 		<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 		<script>
 			(function(src) {
@@ -44,24 +35,22 @@
 					var s = document.getElementsByTagName('script')[0];
 					s.parentNode.insertBefore(script, s);
 				}
-			}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^2.0.1,o-syntax-highlight@^1.5.1'));
+			}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.6,o-syntax-highlight@^3.0.1,o-header-services@^4.0.3,o-footer-services@^3.0.2'));
 		</script>
 
 	</head>
 	<body data-o-component="o-syntax-highlight">
-		<div class="o-layout" data-o-component="o-layout">
+		<div class="o-layout o-layout--landing" data-o-component="o-layout">
 
-			{{> header}}
-
-			<div class="o-layout__sidebar">
-				<!-- automatically generated sidebar here	 -->
+			<div class="o-layout__header">
+				{{> header}}
 			</div>
 
-			<div class="o-layout__main">
-				{{{body}}}
-			</div>
+			{{{body}}}
 
-			{{> footer}}
+			<div class="o-layout__footer">
+				{{> footer}}
+			</div>
 
 		</div>
 	</body>

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="o-layout__footer o-footer-services">
+<footer class="o-footer-services">
 	<div class="o-footer-services__container">
 		<div class="o-footer-services__wrapper o-footer-services__wrapper--top">
 			<a class="o-footer-services__icon-link o-footer-services__icon-link--github" href="http://github.com/financial-times/origami-bower-registry">View project on GitHub</a>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -1,10 +1,8 @@
-<header class="o-header-services o-layout__header" data-o-component="o-header">
-	<div class="o-header-services__top o-header-services__container">
-		<div class="o-header-services__ftlogo"></div>
+<header class="o-header-services" data-o-component="o-header-services">
+	<div class="o-header-services__top">
+		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
-			<h1 class="o-header-services__product-name">
-				<a href="/">Origami Bower Registry</a>
-			</h1>
+			<a class="o-header-services__product-name" href="/">Origami Bower Registry</a>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
I've given this a bit of an overhaul, it's a single page so landing layout made sense. Resolves #126.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<thead>
<tbody>
<tr>
<td><img src="https://user-images.githubusercontent.com/138944/78797080-211ce180-79af-11ea-88a0-1a574c6c4c4c.png" alt="Before" /></td>
<td><img src="https://user-images.githubusercontent.com/138944/78797095-27ab5900-79af-11ea-8bfe-13ce14e8dc88.png" alt="After" /></td>
</tr>
<tbody>
</table>