### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -2,7 +2,7 @@ name: Deploy to staging and test
 on:
   push:
     branches:
-      - master
+      - $default-branch
 jobs:
   deploy-to-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will help with any future work on renaming the default branch name.