### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -26,24 +26,6 @@ https://origami-bower-registry.ft.com
 
 Heroku
 
-## Architecture
-
-This is mostly a Node.js application but with the following external components:
-
-*   An S3 bucket which contains a cache of JSON data
-*   An [organisation-wide Webhook](https://github.com/organizations/Financial-Times/settings/hooks) on the Financial-Times GitHub
-
-### Loading Data
-
-1.  When this service starts, the first thing it does is fetches a JSON file from an S3 bucket. If this bucket isn't available then the application will ignore it – the JSON data is a cache, and is much faster to access than crawling the GitHub API
-2.  Having loaded the cached data (or not), the application makes several requests to the GitHub API to fetch every repository name in the Financial-Times GitHub organisation. It then discards the original cached JSON data
-3.  The application replaces the JSON file in the S3 bucket with a new fresh copy of the data in GitHub, so that next time the application starts it has the latest data
-
-### Ingestion
-
-1.  When a repository is created, renamed, or deleted on the Financial Times GitHub, an organisation-wide webhook makes a request to this service
-2.  The service then performs step 2 and 3 in "Loading Data" outlined above, ensuring that all of the data is fresh
-
 ## Contains Personal Data
 
 No
@@ -114,6 +96,23 @@ This is the name of the Heroku pipeline for this system. If you don't have a pip
 ...or delete this placeholder if not applicable to this system
 -->
 
+## First Line Troubleshooting
+
+There are a few things you can try before contacting the Origami team:
+
+1.  Verify that GitHub and S3 are up. Either of these being down could cause downtime for this application. See [GitHub's status page](https://www.githubstatus.com/) and the [Registry Data's `__gtg` endpoint](https://origami-bower-registry-data.ft.com/__gtg).
+2.  Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
+
+## Second Line Troubleshooting
+
+If the application is failing entirely, you'll need to check a couple of things:
+
+1.  Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
+2.  Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
+3.  Check the Splunk logs (see the monitoring section of this runbook for the link)
+
+If only a few things aren't working, the Splunk logs (see monitoring) are the best place to start debugging. Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
+
 ## Monitoring
 
 *   [Grafana dashboard][grafana]: graph memory, load, and number of requests
@@ -134,23 +133,6 @@ This is the name of the Heroku pipeline for this system. If you don't have a pip
 [sentry-qa]: https://sentry.io/nextftcom/origami-bower-registry-qa/
 
 [splunk]: https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%2Fvar%2Flog%2Fapps%2Fheroku%2Forigami-bower-registry-*
-
-## First Line Troubleshooting
-
-There are a few things you can try before contacting the Origami team:
-
-1.  Verify that GitHub and S3 are up. Either of these being down could cause downtime for this application. See [GitHub's status page](https://www.githubstatus.com/) and the [Registry Data's `__gtg` endpoint](https://origami-bower-registry-data.ft.com/__gtg).
-2.  Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
-
-## Second Line Troubleshooting
-
-If the application is failing entirely, you'll need to check a couple of things:
-
-1.  Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
-2.  Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
-3.  Check the Splunk logs (see the monitoring section of this runbook for the link)
-
-If only a few things aren't working, the Splunk logs (see monitoring) are the best place to start debugging. Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
 
 ## Failover Details
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Bower Registry
 
 Install Financial Times GitHub repositories as Bower components
+
+## Code
+
+origami-bower-registry
 
 ## Service Tier
 
@@ -18,38 +26,39 @@ https://origami-bower-registry.ft.com
 
 Heroku
 
+## Architecture
+
+This is mostly a Node.js application but with the following external components:
+
+*   An S3 bucket which contains a cache of JSON data
+*   An [organisation-wide Webhook](https://github.com/organizations/Financial-Times/settings/hooks) on the Financial-Times GitHub
+
+### Loading Data
+
+1.  When this service starts, the first thing it does is fetches a JSON file from an S3 bucket. If this bucket isn't available then the application will ignore it – the JSON data is a cache, and is much faster to access than crawling the GitHub API
+2.  Having loaded the cached data (or not), the application makes several requests to the GitHub API to fetch every repository name in the Financial-Times GitHub organisation. It then discards the original cached JSON data
+3.  The application replaces the JSON file in the S3 bucket with a new fresh copy of the data in GitHub, so that next time the application starts it has the latest data
+
+### Ingestion
+
+1.  When a repository is created, renamed, or deleted on the Financial Times GitHub, an organisation-wide webhook makes a request to this service
+2.  The service then performs step 2 and 3 in "Loading Data" outlined above, ensuring that all of the data is fresh
+
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Known About By
-
-* lee.moody
-* jake.champion
-* rowan.manning
-
-## Dependencies
-
-* github
-* heroku
-* ft-fastly
-
-## Healthchecks
-
-* origami-bower-registry-us.herokuapp.com-https
-* origami-bower-registry-eu.herokuapp.com-https
+No
 
 ## Failover Architecture Type
 
@@ -83,52 +92,65 @@ Manual
 
 This is mostly a Node.js application but with the following external components:
 
-  - An S3 bucket which contains a cache of JSON data
-  - An [organisation-wide Webhook](https://github.com/organizations/Financial-Times/settings/hooks) on the Financial-Times GitHub
+*   An S3 bucket which contains a cache of JSON data
+*   An [organisation-wide Webhook](https://github.com/organizations/Financial-Times/settings/hooks) on the Financial-Times GitHub
 
 ### Loading Data
 
-1. When this service starts, the first thing it does is fetches a JSON file from an S3 bucket. If this bucket isn't available then the application will ignore it – the JSON data is a cache, and is much faster to access than crawling the GitHub API
-2. Having loaded the cached data (or not), the application makes several requests to the GitHub API to fetch every repository name in the Financial-Times GitHub organisation. It then discards the original cached JSON data
-3. The application replaces the JSON file in the S3 bucket with a new fresh copy of the data in GitHub, so that next time the application starts it has the latest data
+1.  When this service starts, the first thing it does is fetches a JSON file from an S3 bucket. If this bucket isn't available then the application will ignore it – the JSON data is a cache, and is much faster to access than crawling the GitHub API
+2.  Having loaded the cached data (or not), the application makes several requests to the GitHub API to fetch every repository name in the Financial-Times GitHub organisation. It then discards the original cached JSON data
+3.  The application replaces the JSON file in the S3 bucket with a new fresh copy of the data in GitHub, so that next time the application starts it has the latest data
 
 ### Ingestion
 
-1. When a repository is created, renamed, or deleted on the Financial Times GitHub, an organisation-wide webhook makes a request to this service
-2. The service then performs step 2 and 3 in "Loading Data" outlined above, ensuring that all of the data is fresh
+1.  When a repository is created, renamed, or deleted on the Financial Times GitHub, an organisation-wide webhook makes a request to this service
+2.  The service then performs step 2 and 3 in "Loading Data" outlined above, ensuring that all of the data is fresh
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
+## Monitoring
+
+*   [Grafana dashboard][grafana]: graph memory, load, and number of requests
+*   [Pingdom check (Production EU)][pingdom-eu]: checks that the EU production app is responding
+*   [Pingdom check (Production US)][pingdom-us]: checks that the US production app is responding
+*   [Sentry dashboard (Production)][sentry-production]: records application errors in the production app
+*   [Sentry dashboard (QA)][sentry-qa]: records application errors in the QA app
+*   [Splunk (Production)][splunk]: query application logs
+
+[grafana]: http://grafana.ft.com/dashboard/db/origami-bower-registry
+
+[pingdom-eu]: https://my.pingdom.com/newchecks/checks#check=2952910
+
+[pingdom-us]: https://my.pingdom.com/newchecks/checks#check=2952919
+
+[sentry-production]: https://sentry.io/nextftcom/origami-bower-registry-product/
+
+[sentry-qa]: https://sentry.io/nextftcom/origami-bower-registry-qa/
+
+[splunk]: https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%2Fvar%2Flog%2Fapps%2Fheroku%2Forigami-bower-registry-*
 
 ## First Line Troubleshooting
 
 There are a few things you can try before contacting the Origami team:
 
-1. Verify that GitHub and S3 are up. Either of these being down could cause downtime for this application. See [GitHub's status page](https://www.githubstatus.com/) and the [Registry Data's `__gtg` endpoint](https://origami-bower-registry-data.ft.com/__gtg).
-2. Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
+1.  Verify that GitHub and S3 are up. Either of these being down could cause downtime for this application. See [GitHub's status page](https://www.githubstatus.com/) and the [Registry Data's `__gtg` endpoint](https://origami-bower-registry-data.ft.com/__gtg).
+2.  Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
 
 ## Second Line Troubleshooting
 
 If the application is failing entirely, you'll need to check a couple of things:
 
-1. Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
-2. Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
-2. Check the Splunk logs (see the monitoring section of this runbook for the link)
+1.  Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
+2.  Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/748923ac-b3c0-4289-a0ac-c26b5a7dbe3a))
+3.  Check the Splunk logs (see the monitoring section of this runbook for the link)
 
 If only a few things aren't working, the Splunk logs (see monitoring) are the best place to start debugging. Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
-
-## Monitoring
-
-* [Grafana dashboard][grafana]: graph memory, load, and number of requests
-* [Pingdom check (Production EU)][pingdom-eu]: checks that the EU production app is responding
-* [Pingdom check (Production US)][pingdom-us]: checks that the US production app is responding
-* [Sentry dashboard (Production)][sentry-production]: records application errors in the production app
-* [Sentry dashboard (QA)][sentry-qa]: records application errors in the QA app
-* [Splunk (Production)][splunk]: query application logs
-
-[grafana]: http://grafana.ft.com/dashboard/db/origami-bower-registry
-[pingdom-eu]: https://my.pingdom.com/newchecks/checks#check=2952910
-[pingdom-us]: https://my.pingdom.com/newchecks/checks#check=2952919
-[sentry-production]: https://sentry.io/nextftcom/origami-bower-registry-product/
-[sentry-qa]: https://sentry.io/nextftcom/origami-bower-registry-qa/
-[splunk]: https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%2Fvar%2Flog%2Fapps%2Fheroku%2Forigami-bower-registry-*
 
 ## Failover Details
 
@@ -146,8 +168,7 @@ The application is deployed to QA whenever a new commit is pushed to the `master
 
 This service uses two keys:
 
-1. GitHub (with read permissions only)
-2. AWS (read/write permissions for a single S3 bucket)
+1.  GitHub (with read permissions only)
+2.  AWS (read/write permissions for a single S3 bucket)
 
 The process for rotating these keys is manual, via the GitHub and AWS interfaces.
-


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-bower-registry/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-bower-registry** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-bower-registry** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-bower-registry).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
